### PR TITLE
Add WHOIS support, Fix MODE downstream support

### DIFF
--- a/irc.go
+++ b/irc.go
@@ -86,6 +86,13 @@ const (
 
 const stdMembershipPrefixes = "~&@%+"
 
+func (m membership) String() string {
+	if m == 0 {
+		return ""
+	}
+	return string(m)
+}
+
 func parseMembershipPrefix(s string) (prefix membership, nick string) {
 	// TODO: any prefix from PREFIX RPL_ISUPPORT
 	if strings.IndexByte(stdMembershipPrefixes, s[0]) >= 0 {


### PR DESCRIPTION
(two unrelated commits in one PR to avoid rebasing issues)

# Add WHOIS support

# Fix MODE downstream support

I am not sure about caching channel modes.
- Handling channel modes is a bit hard, as there are [4 different kinds of channel modes](https://modern.ircdocs.horse/#mode-message), some of which can have arguments, lists, ... Only modes without arguments are currently supported
- Currently we never send any MODE message to the server to initialize the mode cache, so it's always empty (until an external change to the modes is made)
- Is caching modes really useful and something a bouncer should do?