### PR TITLE
Add support for custom network on-connect messages

### DIFF
--- a/upstream.go
+++ b/upstream.go
@@ -1189,6 +1189,15 @@ func (uc *upstreamConn) runUntilRegistered() error {
 		}
 	}
 
+	for _, command := range uc.network.ConnectCommands {
+		m, err := irc.ParseMessage(command)
+		if err != nil {
+			uc.logger.Printf("failed to parse connect command %q: %v", command, err)
+		} else {
+			uc.SendMessage(m)
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Some servers use custom IRC bots with custom commands for registering to
specific services after connection.

This adds support for setting a custom raw IRC message, that will be
sent after registering to a network.