### PR TITLE
Add support for skipping TLS certificate verification

### DIFF
--- a/service.go
+++ b/service.go
@@ -104,7 +104,7 @@ func init() {
 		"network": {
 			children: serviceCommandSet{
 				"create": {
-					usage:  "-addr <addr> [-name name] [-username username] [-pass pass] [-realname realname] [-nick nick] [[-connect-command command] ...]",
+					usage:  "-addr <addr> [-name name] [-username username] [-pass pass] [-realname realname] [-nick nick] [[-connect-command command] ...] [-insecure-tls]",
 					desc:   "add a new network",
 					handle: handleServiceCreateNetwork,
 				},
@@ -195,6 +195,7 @@ func handleServiceCreateNetwork(dc *downstreamConn, params []string) error {
 	nick := fs.String("nick", "", "")
 	var connectCommands stringSliceVar
 	fs.Var(&connectCommands, "connect-command", "")
+	insecureTls := fs.Bool("insecure-tls", false, "")
 
 	if err := fs.Parse(params); err != nil {
 		return err
@@ -223,6 +224,7 @@ func handleServiceCreateNetwork(dc *downstreamConn, params []string) error {
 		Realname:        *realname,
 		Nick:            *nick,
 		ConnectCommands: connectCommands,
+		InsecureTLS:     *insecureTls,
 	})
 	if err != nil {
 		return fmt.Errorf("could not create network: %v", err)

--- a/upstream.go
+++ b/upstream.go
@@ -74,7 +74,9 @@ func connectToUpstream(network *network) (*upstreamConn, error) {
 	dialer := net.Dialer{Timeout: connectTimeout}
 
 	logger.Printf("connecting to TLS server at address %q", addr)
-	netConn, err := tls.DialWithDialer(&dialer, "tcp", addr, nil)
+	netConn, err := tls.DialWithDialer(&dialer, "tcp", addr, &tls.Config{
+		InsecureSkipVerify: network.InsecureTLS,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to dial %q: %v", addr, err)
 	}


### PR DESCRIPTION
Some servers use expired TLS certificates. Connecting to these networks
is only possible by skipping TLS certificate verification. This feature
is also useful for connecting to servers with different hostnames
(although a specific option for setting the right hostname could be
added in the future).

This adds support for a flag in the service command `network create`
that lets users disable TLS certificate verification for a particular
network.