### PR TITLE
Add support for plaintext upstreams (-no-tls)

### DIFF
--- a/db.go
+++ b/db.go
@@ -33,6 +33,7 @@ type Network struct {
 	Pass            string
 	ConnectCommands []string
 	SASL            SASL
+	NoTLS           bool
 }
 
 func (net *Network) GetName() string {
@@ -69,6 +70,7 @@ CREATE TABLE Network (
 	sasl_mechanism VARCHAR(255),
 	sasl_plain_username VARCHAR(255),
 	sasl_plain_password VARCHAR(255),
+	no_tls INTEGER,
 	FOREIGN KEY(user) REFERENCES User(username),
 	UNIQUE(user, addr, nick)
 );
@@ -86,6 +88,7 @@ CREATE TABLE Channel (
 var migrations = []string{
 	"", // migration #0 is reserved for schema initialization
 	"ALTER TABLE Network ADD COLUMN connect_commands VARCHAR(1023)",
+	"ALTER TABLE Network ADD COLUMN no_tls INTEGER DEFAULT 0",
 }
 
 type DB struct {
@@ -169,6 +172,24 @@ func toStringPtr(s string) *string {
 	return &s
 }
 
+func fromBoolPtr(ptr *int) bool {
+	if ptr == nil {
+		return false
+	}
+	if *ptr == 0 {
+		return false
+	}
+	return true
+}
+
+func toBoolPtr(b bool) *int {
+	v := 0
+	if b {
+		v = 1
+	}
+	return &v
+}
+
 func (db *DB) ListUsers() ([]User, error) {
 	db.lock.RLock()
 	defer db.lock.RUnlock()
@@ -237,7 +258,7 @@ func (db *DB) ListNetworks(username string) ([]Network, error) {
 	defer db.lock.RUnlock()
 
 	rows, err := db.db.Query(`SELECT id, name, addr, nick, username, realname, pass,
-			connect_commands, sasl_mechanism, sasl_plain_username, sasl_plain_password
+			connect_commands, sasl_mechanism, sasl_plain_username, sasl_plain_password, no_tls
 		FROM Network
 		WHERE user = ?`,
 		username)
@@ -251,8 +272,9 @@ func (db *DB) ListNetworks(username string) ([]Network, error) {
 		var net Network
 		var name, username, realname, pass, connectCommands *string
 		var saslMechanism, saslPlainUsername, saslPlainPassword *string
+		var noTLS *int
 		err := rows.Scan(&net.ID, &name, &net.Addr, &net.Nick, &username, &realname,
-			&pass, &connectCommands, &saslMechanism, &saslPlainUsername, &saslPlainPassword)
+			&pass, &connectCommands, &saslMechanism, &saslPlainUsername, &saslPlainPassword, &noTLS)
 		if err != nil {
 			return nil, err
 		}
@@ -266,6 +288,7 @@ func (db *DB) ListNetworks(username string) ([]Network, error) {
 		net.SASL.Mechanism = fromStringPtr(saslMechanism)
 		net.SASL.Plain.Username = fromStringPtr(saslPlainUsername)
 		net.SASL.Plain.Password = fromStringPtr(saslPlainPassword)
+		net.NoTLS = fromBoolPtr(noTLS)
 		networks = append(networks, net)
 	}
 	if err := rows.Err(); err != nil {
@@ -284,6 +307,7 @@ func (db *DB) StoreNetwork(username string, network *Network) error {
 	realname := toStringPtr(network.Realname)
 	pass := toStringPtr(network.Pass)
 	connectCommands := toStringPtr(strings.Join(network.ConnectCommands, "\r\n"))
+	noTLS := toBoolPtr(network.NoTLS)
 
 	var saslMechanism, saslPlainUsername, saslPlainPassword *string
 	if network.SASL.Mechanism != "" {
@@ -301,18 +325,18 @@ func (db *DB) StoreNetwork(username string, network *Network) error {
 	if network.ID != 0 {
 		_, err = db.db.Exec(`UPDATE Network
 			SET name = ?, addr = ?, nick = ?, username = ?, realname = ?, pass = ?, connect_commands = ?,
-				sasl_mechanism = ?, sasl_plain_username = ?, sasl_plain_password = ?
+				sasl_mechanism = ?, sasl_plain_username = ?, sasl_plain_password = ?, no_tls = ?
 			WHERE id = ?`,
 			netName, network.Addr, network.Nick, netUsername, realname, pass, connectCommands,
-			saslMechanism, saslPlainUsername, saslPlainPassword, network.ID)
+			saslMechanism, saslPlainUsername, saslPlainPassword, noTLS, network.ID)
 	} else {
 		var res sql.Result
 		res, err = db.db.Exec(`INSERT INTO Network(user, name, addr, nick, username,
 				realname, pass, connect_commands, sasl_mechanism, sasl_plain_username,
-				sasl_plain_password)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+				sasl_plain_password, no_tls)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			username, netName, network.Addr, network.Nick, netUsername, realname, pass, connectCommands,
-			saslMechanism, saslPlainUsername, saslPlainPassword)
+			saslMechanism, saslPlainUsername, saslPlainPassword, noTLS)
 		if err != nil {
 			return err
 		}

--- a/service.go
+++ b/service.go
@@ -104,7 +104,7 @@ func init() {
 		"network": {
 			children: serviceCommandSet{
 				"create": {
-					usage:  "-addr <addr> [-name name] [-username username] [-pass pass] [-realname realname] [-nick nick] [[-connect-command command] ...]",
+					usage:  "-addr <addr> [-name name] [-username username] [-pass pass] [-realname realname] [-nick nick] [[-connect-command command] ...] [-no-tls]",
 					desc:   "add a new network",
 					handle: handleServiceCreateNetwork,
 				},
@@ -195,6 +195,7 @@ func handleServiceCreateNetwork(dc *downstreamConn, params []string) error {
 	nick := fs.String("nick", "", "")
 	var connectCommands stringSliceVar
 	fs.Var(&connectCommands, "connect-command", "")
+	noTLS := fs.Bool("no-tls", false, "")
 
 	if err := fs.Parse(params); err != nil {
 		return err
@@ -223,6 +224,7 @@ func handleServiceCreateNetwork(dc *downstreamConn, params []string) error {
 		Realname:        *realname,
 		Nick:            *nick,
 		ConnectCommands: connectCommands,
+		NoTLS:           *noTLS,
 	})
 	if err != nil {
 		return fmt.Errorf("could not create network: %v", err)

--- a/upstream.go
+++ b/upstream.go
@@ -73,8 +73,15 @@ func connectToUpstream(network *network) (*upstreamConn, error) {
 
 	dialer := net.Dialer{Timeout: connectTimeout}
 
-	logger.Printf("connecting to TLS server at address %q", addr)
-	netConn, err := tls.DialWithDialer(&dialer, "tcp", addr, nil)
+	var netConn net.Conn
+	var err error
+	if !network.NoTLS {
+		logger.Printf("connecting to TLS server at address %q", addr)
+		netConn, err = tls.DialWithDialer(&dialer, "tcp", addr, nil)
+	} else {
+		logger.Printf("connecting to plain-text server at address %q", addr)
+		netConn, err = dialer.Dial("tcp", addr)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to dial %q: %v", addr, err)
 	}


### PR DESCRIPTION
Some servers do not support TLS, or have invalid, expired, or
self-signed TLS certificates. While the right fix would be to contact
each server owner to add support for valid TLS, supporting plaintext
upstream connections is sometimes necessary.

This adds support for a flag in the service command `network create`
that lets users disable TLS for a particular network.