### PR TITLE
Fix joining only one saved channel per network

### DIFF
--- a/user.go
+++ b/user.go
@@ -65,6 +65,7 @@ type network struct {
 func newNetwork(user *user, record *Network, channels []Channel) *network {
 	m := make(map[string]*Channel, len(channels))
 	for _, ch := range channels {
+		ch := ch
 		m[ch.Name] = &ch
 	}
 
@@ -229,6 +230,7 @@ func (u *user) run() {
 	}
 
 	for _, record := range networks {
+		record := record
 		channels, err := u.srv.db.ListChannels(record.ID)
 		if err != nil {
 			u.srv.Logger.Printf("failed to list channels for user %q, network %q: %v", u.Username, record.GetName(), err)


### PR DESCRIPTION
This fixes a serious bug added in 276ce12e, where in newNetwork all
channels point to the same channel, which causes soju to only join a
single channel when connecting to an upstream network.

This also adds the same kind of reassignment of a for loop variable in
user.run(), even though that function currently works correctly, as a
sanity improvement in case this function is changed in the future.