### PR TITLE
Add support for the extended-join capability

### DIFF
--- a/downstream.go
+++ b/downstream.go
@@ -75,8 +75,9 @@ var permanentDownstreamCaps = map[string]string{
 // needAllDownstreamCaps is the list of downstream capabilities that
 // require support from all upstreams to be enabled
 var needAllDownstreamCaps = map[string]string{
-	"away-notify":  "",
-	"multi-prefix": "",
+	"away-notify":   "",
+	"extended-join": "",
+	"multi-prefix":  "",
 }
 
 type downstreamConn struct {
@@ -280,6 +281,9 @@ func (dc *downstreamConn) SendMessage(msg *irc.Message) {
 				delete(msg.Tags, name)
 			}
 		}
+	}
+	if msg.Command == "JOIN" && !dc.caps["extended-join"] {
+		msg.Params = msg.Params[:1]
 	}
 
 	dc.conn.SendMessage(msg)

--- a/upstream.go
+++ b/upstream.go
@@ -26,6 +26,7 @@ import (
 var permanentUpstreamCaps = map[string]bool{
 	"away-notify":      true,
 	"batch":            true,
+	"extended-join":    true,
 	"labeled-response": true,
 	"message-tags":     true,
 	"multi-prefix":     true,


### PR DESCRIPTION
This simple implementation only advertises extended-join to downstreams
when all upstreams support it.

In the future, it could be modified so that soju buffers incoming
upstream JOINs, sends a WHO, waits for the reply, and sends an extended
join to the downstream; so that soju could advertise that capability
even when some or all upstreams do not support it. This is not the case
in this commit.