### PR TITLE
Set a higher timeout for proxyproto listeners

### DIFF
--- a/cmd/soju/main.go
+++ b/cmd/soju/main.go
@@ -253,5 +253,6 @@ func proxyProtoListener(ln net.Listener, srv *soju.Server) net.Listener {
 			}
 			return proxyproto.IGNORE, nil
 		},
+		ReadHeaderTimeout: 5 * time.Second,
 	}
 }


### PR DESCRIPTION
go-proxyproto added support for a read timeout in 0.6.0[1] and
defaulted it to 200ms. After this time if no data is read on
the socket, it is closed.

This is _really_ low if the underlying connection is a TLS
one as no data pops out the other end until the handshake is
done. It effectively limits you to TLS connections within
a 50ms RTT of your bouncer with clients that are fast enough
at responding.

It appears that HexChat on Arch is somehow slow enough at
TLS connections thant it consistently takes longer than
200ms even over localhost, meaning it outright can't connect
to soju any longer.

To make this a lot less painful, have soju pass in a read
timeout of 5 seconds. This feels like a reasonable tradeoff
between keeping (possibly malicious) connections open and
accepting the realities of network connections.

[1]: https://github.com/pires/go-proxyproto/issues/65