### PR TITLE
Add support for downstream labeled-response

### DIFF
--- a/upstream.go
+++ b/upstream.go
@@ -185,9 +185,10 @@ func (uu *upstreamUser) updateFrom(update *upstreamUser) {
 }
 
 type pendingUpstreamCommand struct {
-	downstreamID uint64
-	msg          *irc.Message
-	sentAt       time.Time
+	downstreamID    uint64
+	downstreamLabel string
+	msg             *irc.Message
+	sentAt          time.Time
 }
 
 type upstreamConn struct {
@@ -450,6 +451,8 @@ func (uc *upstreamConn) forwardMsgByID(ctx context.Context, id uint64, msg *irc.
 }
 
 func (uc *upstreamConn) abortPendingCommands() {
+	// TODO: support labeled-response
+
 	ctx := context.TODO()
 	for _, l := range uc.pendingCmds {
 		for _, pendingCmd := range l {
@@ -503,7 +506,7 @@ func (uc *upstreamConn) sendNextPendingCommand(cmd string) {
 		return
 	}
 	pendingCmd := &uc.pendingCmds[cmd][0]
-	uc.SendMessageLabeled(context.TODO(), pendingCmd.downstreamID, pendingCmd.msg)
+	uc.SendMessageLabeled(context.TODO(), pendingCmd.downstreamID, pendingCmd.downstreamLabel, pendingCmd.msg)
 	pendingCmd.sentAt = time.Now()
 }
 
@@ -516,8 +519,9 @@ func (uc *upstreamConn) enqueueCommand(dc *downstreamConn, msg *irc.Message) {
 	}
 
 	uc.pendingCmds[msg.Command] = append(uc.pendingCmds[msg.Command], pendingUpstreamCommand{
-		downstreamID: dc.id,
-		msg:          msg,
+		downstreamID:    dc.id,
+		downstreamLabel: dc.label,
+		msg:             msg,
 	})
 
 	// If we didn't get a reply after a while, just give up
@@ -580,6 +584,26 @@ func (uc *upstreamConn) parseMembershipPrefix(s string) (ms xirc.MembershipSet, 
 	return memberships, s[i:]
 }
 
+func (uc *upstreamConn) parseLabel(label string) (downstreamID uint64, downstreamLabel string, err error) {
+	if label == "" {
+		return
+	}
+	parts := strings.SplitN(label, "-", 4)
+	if len(parts) < 4 {
+		err = errors.New("not enough arguments")
+	} else if parts[0] != "sd" {
+		err = fmt.Errorf("expected %v, got %v", "sd", parts[0])
+	} else {
+		downstreamID, err = strconv.ParseUint(parts[1], 10, 64)
+	}
+	if err != nil {
+		err = fmt.Errorf("unexpected message label: invalid downstream reference for label %q: %v", label, err)
+		return
+	}
+	downstreamLabel = parts[3]
+	return
+}
+
 func (uc *upstreamConn) handleMessage(ctx context.Context, msg *irc.Message) error {
 	var label string
 	if l, ok := msg.Tags["label"]; ok {
@@ -588,6 +612,7 @@ func (uc *upstreamConn) handleMessage(ctx context.Context, msg *irc.Message) err
 	}
 
 	var msgBatch *upstreamBatch
+	batchLabel := false
 	if batchName, ok := msg.Tags["batch"]; ok {
 		b, ok := uc.batches[batchName]
 		if !ok {
@@ -595,22 +620,34 @@ func (uc *upstreamConn) handleMessage(ctx context.Context, msg *irc.Message) err
 		}
 		msgBatch = &b
 		if label == "" {
+			batchLabel = true
 			label = msgBatch.Label
 		}
 		delete(msg.Tags, "batch")
 	}
 
-	var downstreamID uint64
-	if label != "" {
-		var labelOffset uint64
-		n, err := fmt.Sscanf(label, "sd-%d-%d", &downstreamID, &labelOffset)
-		if err == nil && n < 2 {
-			err = errors.New("not enough arguments")
-		}
-		if err != nil {
-			return fmt.Errorf("unexpected message label: invalid downstream reference for label %q: %v", label, err)
+	downstreamID, downstreamLabel, err := uc.parseLabel(label)
+	if err != nil {
+		return err
+	}
+	if downstreamID != 0 {
+		if batchLabel {
+			// label comes from batch, send the message as part of that batch
+			uc.forEachDownstreamByID(downstreamID, func(dc *downstreamConn) {
+				dc.labelBatch = msg.Tags["batch"]
+			})
+		} else {
+			// label comes from this message, respond to the message with that label
+			uc.forEachDownstreamByID(downstreamID, func(dc *downstreamConn) {
+				dc.label = downstreamLabel
+			})
 		}
 	}
+	defer func() {
+		uc.forEachDownstreamByID(downstreamID, func(dc *downstreamConn) {
+			dc.FlushBatch()
+		})
+	}()
 
 	if msg.Prefix == nil {
 		msg.Prefix = uc.serverPrefix
@@ -1064,12 +1101,39 @@ func (uc *upstreamConn) handleMessage(ctx context.Context, msg *irc.Message) err
 				Outer:  msgBatch,
 				Label:  label,
 			}
+			if downstreamID != 0 && downstreamLabel != "" {
+				uc.forEachDownstreamByID(downstreamID, func(dc *downstreamConn) {
+					dc.label = ""
+					dc.SendMessage(ctx, &irc.Message{
+						Prefix:  uc.srv.prefix(),
+						Command: "BATCH",
+						Params:  msg.Params,
+						Tags: irc.Tags{
+							"label": downstreamLabel,
+						},
+					})
+				})
+			}
 		} else if strings.HasPrefix(tag, "-") {
 			tag = tag[1:]
 			if _, ok := uc.batches[tag]; !ok {
 				return fmt.Errorf("unknown BATCH reference tag: %q", tag)
 			}
+			label := uc.batches[tag].Label
 			delete(uc.batches, tag)
+
+			// BATCH - does not have @label/@batch attached to it, so downstreamID is empty.
+			// extract it back from the batch struct.
+			downstreamID, downstreamLabel, err := uc.parseLabel(label)
+			if downstreamID != 0 && downstreamLabel != "" && err == nil {
+				uc.forEachDownstreamByID(downstreamID, func(dc *downstreamConn) {
+					dc.SendMessage(ctx, &irc.Message{
+						Prefix:  uc.srv.prefix(),
+						Command: "BATCH",
+						Params:  msg.Params,
+					})
+				})
+			}
 		} else {
 			return fmt.Errorf("unexpected BATCH reference tag: missing +/- prefix: %q", tag)
 		}
@@ -2100,12 +2164,12 @@ func (uc *upstreamConn) SendMessage(ctx context.Context, msg *irc.Message) {
 	uc.conn.SendMessage(ctx, msg)
 }
 
-func (uc *upstreamConn) SendMessageLabeled(ctx context.Context, downstreamID uint64, msg *irc.Message) {
+func (uc *upstreamConn) SendMessageLabeled(ctx context.Context, downstreamID uint64, label string, msg *irc.Message) {
 	if uc.caps.IsEnabled("labeled-response") {
 		if msg.Tags == nil {
 			msg.Tags = make(irc.Tags)
 		}
-		msg.Tags["label"] = fmt.Sprintf("sd-%d-%d", downstreamID, uc.nextLabelID)
+		msg.Tags["label"] = fmt.Sprintf("sd-%d-%d-%s", downstreamID, uc.nextLabelID, label)
 		uc.nextLabelID++
 	}
 	uc.SendMessage(ctx, msg)

--- a/user.go
+++ b/user.go
@@ -798,10 +798,7 @@ func (u *user) run() {
 				break
 			}
 			err := dc.handleMessage(context.TODO(), msg)
-			if ircErr, ok := err.(ircError); ok {
-				ircErr.Message.Prefix = dc.srv.prefix()
-				dc.SendMessage(context.TODO(), ircErr.Message)
-			} else if err != nil {
+			if err != nil {
 				dc.logger.Printf("failed to handle message %q: %v", msg, err)
 				dc.Close()
 			}


### PR DESCRIPTION
This adds support for downstream labeled response. Instead of doing
specific processing on each SendMessage call site, the idea is to add
some logic to SendMessage.

The cap is advertised only in single-upstream mode when the upstream
server supports it too.

----

When handling a downstream message, we store the label of the current
message we're processing, in the downstream struct. (This should be
understood as data whose lifetime is limited to the processing of one
message. It is reset when we're done handling the message.)

During the handling of that downstream message, at any point, when we
send out messages to this downstream:
- if we're not handling a particular label, send it as is
- else if this is the first message we're sending, store/buffer it
- else, open a batch, send/flush the pending message and our message in
  that batch.

Then, at the end of the processing:
- if we're not handling a particular label, do nothing
- if we have a pending message, send it without a batch
- if we had opened a batch, close it
- if we didnt send anything, send ACK

This enables us to always send the minimum amount of messages.
- 2+ messages generates a BATCH
- 1 message generates a message with label
- 0 message generates an ACK with label

While we may send messages to many upstreams and downstreams, obviosuly
only the downstream from which the message we're processing was received
is affected.

----

A special case affects the above behavior, which makes it differ from a
typical server implementation. Soju handles many commands by forwarding
the command to the server, ending the downstream message handling
without responding anything, then forwarding the server response later
when we receive it.

In this case we must not send an empty ACK at the end of our routine,
but we must instead not send anything, copy the message label to the
message we're sending to the server, and then when we get the response
(or batches) from the server, forward that to the downstream.

Examples:

    dc->soju: @label=foo BAR
    soju->uc: @label=foo BAR
    uc->soju: @label=foo BAZ
    soju->dc: @label=foo BAZ

    dc->soju: @label=foo BAR
    soju->uc: @label=foo BAR
    uc->soju: @label=foo BATCH +b labeled-response
    soju->dc: @label=foo BATCH +b labeled-response
    uc->soju: @batch=b BAZ
    soju->dc: @batch=b BAZ
    uc->soju: BATCH -b
    soju->dc: BATCH -b

(This is a bit more complicated because we wrap downstream labels with
our own labels.)

The patch therefore adds a DeferredResponse method to downstreamConn,
which basically tells it not to send an empty ACK at the end of the
routine, because we'll do a proper response later.

----

When handling upstream messages, we extract the downstream label from
the server labeled response, if it exists. We also extract the
downstream batch tag if it corresponds to a label. We store that info in
the downstreamConn, much like the downstream message handling.

We forward BATCH + and BATCH - as is, even keeping the same batch IDs.

This way, we also support cases where the server responds with a single
message but our logic turns that into multiple messages, or no messages.
(We'd buffer the first message, open a batch, send the messages, close
it etc. just like the downstream message case.)

----

Some cases are a bit more difficult to implement and not really useful.
(And also not mandatory according to the spec since this is
best-effort.) Those were left TODO for now.