### PR TITLE
Make the auto-away functionality configurable

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -131,6 +131,7 @@ type Network struct {
 	Pass            string
 	ConnectCommands []string
 	SASL            SASL
+	AutoAway        bool
 	Enabled         bool
 }
 

--- a/doc/soju.1.scd
+++ b/doc/soju.1.scd
@@ -36,7 +36,7 @@ If a network specified in the username doesn't exist, and the network name is a
 valid hostname, the network will be automatically added.
 
 When all clients are disconnected from the bouncer, the user is automatically
-marked as away.
+marked as away by default.
 
 soju will reload the configuration file, the TLS certificate/key and the MOTD
 file when it receives the HUP signal. The configuration options _listen_, _db_
@@ -216,6 +216,11 @@ abbreviated form, for instance *network* can be abbreviated as *net* or just
 	*-nick* <nickname>
 		Connect with the specified nickname. By default, the account's username
 		is used.
+
+	*-auto-away* true|false
+		Enable or disable the auto-away feature. If the feature is enabled, the
+		user will be marked as away when all clients are disconnected from the
+		bouncer. By default, auto-away is enabled.
 
 	*-enabled* true|false
 		Enable or disable the network. If the network is disabled, the bouncer

--- a/service.go
+++ b/service.go
@@ -201,7 +201,7 @@ func init() {
 		"network": {
 			children: serviceCommandSet{
 				"create": {
-					usage:  "-addr <addr> [-name name] [-username username] [-pass pass] [-realname realname] [-nick nick] [-enabled enabled] [-connect-command command]...",
+					usage:  "-addr <addr> [-name name] [-username username] [-pass pass] [-realname realname] [-nick nick] [-auto-away auto-away] [-enabled enabled] [-connect-command command]...",
 					desc:   "add a new network",
 					handle: handleServiceNetworkCreate,
 				},
@@ -210,7 +210,7 @@ func init() {
 					handle: handleServiceNetworkStatus,
 				},
 				"update": {
-					usage:  "[name] [-addr addr] [-name name] [-username username] [-pass pass] [-realname realname] [-nick nick] [-enabled enabled] [-connect-command command]...",
+					usage:  "[name] [-addr addr] [-name name] [-username username] [-pass pass] [-realname realname] [-nick nick] [-auto-away auto-away] [-enabled enabled] [-connect-command command]...",
 					desc:   "update a network",
 					handle: handleServiceNetworkUpdate,
 				},
@@ -431,7 +431,7 @@ func getNetworkFromArg(dc *downstreamConn, params []string) (*network, []string,
 type networkFlagSet struct {
 	*flag.FlagSet
 	Addr, Name, Nick, Username, Pass, Realname *string
-	Enabled                                    *bool
+	AutoAway, Enabled                          *bool
 	ConnectCommands                            []string
 }
 
@@ -443,6 +443,7 @@ func newNetworkFlagSet() *networkFlagSet {
 	fs.Var(stringPtrFlag{&fs.Username}, "username", "")
 	fs.Var(stringPtrFlag{&fs.Pass}, "pass", "")
 	fs.Var(stringPtrFlag{&fs.Realname}, "realname", "")
+	fs.Var(boolPtrFlag{&fs.AutoAway}, "auto-away", "")
 	fs.Var(boolPtrFlag{&fs.Enabled}, "enabled", "")
 	fs.Var((*stringSliceFlag)(&fs.ConnectCommands), "connect-command", "")
 	return fs
@@ -477,6 +478,9 @@ func (fs *networkFlagSet) update(network *database.Network) error {
 	}
 	if fs.Realname != nil {
 		network.Realname = *fs.Realname
+	}
+	if fs.AutoAway != nil {
+		network.AutoAway = *fs.AutoAway
 	}
 	if fs.Enabled != nil {
 		network.Enabled = *fs.Enabled

--- a/upstream.go
+++ b/upstream.go
@@ -1958,6 +1958,10 @@ func (uc *upstreamConn) produce(target string, msg *irc.Message, originID uint64
 func (uc *upstreamConn) updateAway() {
 	ctx := context.TODO()
 
+	if !uc.network.AutoAway {
+		return
+	}
+
 	away := true
 	uc.forEachDownstream(func(dc *downstreamConn) {
 		if dc.away == nil {


### PR DESCRIPTION
This allows users to enable or disable the auto-away functionality per network. If left unset, the default is to enable the functionality to retain the existing behavior.