### PR TITLE
Build default ISUPPORT passthrough values according to our defaults

### DIFF
--- a/upstream.go
+++ b/upstream.go
@@ -381,6 +381,24 @@ func connectToUpstream(ctx context.Context, network *network) (*upstreamConn, er
 		monitored:             monitorCasemapMap{newCasemapMap()},
 		hasDesiredNick:        true,
 	}
+
+	// Build initial ISUPPORT reflecting the default values.
+	chanModes := make(map[channelModeType]string)
+	for m, t := range stdChannelModes {
+		chanModes[t] += string(m)
+	}
+	chanModeStr := fmt.Sprintf("%s,%s,%s,%s", chanModes[modeTypeA], chanModes[modeTypeB], chanModes[modeTypeC], chanModes[modeTypeD])
+	uc.isupport["CHANMODES"] = &chanModeStr
+	chanTypes := stdChannelTypes
+	uc.isupport["CHANTYPES"] = &chanTypes
+	var membershipModes, membershipPrefixes string
+	for _, m := range stdMemberships {
+		membershipModes += string(m.Mode)
+		membershipPrefixes += string(m.Prefix)
+	}
+	prefix := fmt.Sprintf("(%s)%s", membershipModes, membershipPrefixes)
+	uc.isupport["PREFIX"] = &prefix
+
 	return uc, nil
 }
 


### PR DESCRIPTION
Previously, we would consider CHANTYPES to be #&+!, but would not store that entry in the ISUPPORT map, then causing soju to not send that value in its ISUPPORT to the downstream if it was not overwritten by the upstream.

Instead, we should advertise in our ISUPPORT the same defaults as those we use for our own logic.