### PR TITLE
Support STATUSMSG

### DIFF
--- a/downstream.go
+++ b/downstream.go
@@ -282,6 +282,7 @@ var passthroughIsupport = map[string]bool{
 	"NICKLEN":       true,
 	"PREFIX":        true,
 	"SAFELIST":      true,
+	"STATUSMSG":     true,
 	"TARGMAX":       true,
 	"TOPICLEN":      true,
 	"USERLEN":       true,


### PR DESCRIPTION
This passes the STATUSMSG isupport through, and it ignores statusmsg prefix when routing messages through the PRIVMSG, NOTICE, and TAGMSG handler so they will show up in the correct history. Because it doesn't modify the message the statusmsg sigils show up correctly for the user on receipt.

Without this PR the statusmsg messages still come through to the client, but they get misrouted by clients expecting STATUSMSG to be specified in 005 and they don't go into the right channel history.