### PR TITLE
Forward complete MODE message to upstream when changing modes

### DIFF
--- a/downstream.go
+++ b/downstream.go
@@ -2013,10 +2013,7 @@ func (dc *downstreamConn) handleMessageRegistered(ctx context.Context, msg *irc.
 		if dc.casemap(name) == dc.nickCM {
 			if modeStr != "" {
 				if uc := dc.upstream(); uc != nil {
-					uc.SendMessageLabeled(ctx, dc.id, &irc.Message{
-						Command: "MODE",
-						Params:  []string{uc.nick, modeStr},
-					})
+					uc.SendMessageLabeled(ctx, dc.id, msg)
 				} else {
 					dc.SendMessage(ctx, &irc.Message{
 						Prefix:  dc.srv.prefix(),


### PR DESCRIPTION
On Solanum more arguments are meaningful when changing snomask flags: `MODE nick s +x`. I imagine there are other ircds that could do similar things