### PR TITLE
Fix missing prefix on away numerics

### DIFF
--- a/downstream.go
+++ b/downstream.go
@@ -752,7 +752,7 @@ func (dc *downstreamConn) handleMessageUnregistered(ctx context.Context, msg *ir
 			dc.away = nil
 		}
 
-		dc.SendMessage(ctx, generateAwayReply(dc.away != nil))
+		dc.SendMessage(ctx, generateAwayReply(dc.away != nil, dc.srv.prefix()))
 	default:
 		dc.logger.Debugf("unhandled message: %v", msg)
 		return newUnknownCommandError(msg.Command)
@@ -2583,7 +2583,7 @@ func (dc *downstreamConn) handleMessageRegistered(ctx context.Context, msg *irc.
 			dc.away = nil
 		}
 
-		dc.SendMessage(ctx, generateAwayReply(dc.away != nil))
+		dc.SendMessage(ctx, generateAwayReply(dc.away != nil, dc.srv.prefix()))
 
 		uc := dc.upstream()
 		if uc != nil {

--- a/irc.go
+++ b/irc.go
@@ -299,7 +299,7 @@ func isNumeric(cmd string) bool {
 	return true
 }
 
-func generateAwayReply(away bool) *irc.Message {
+func generateAwayReply(away bool, prefix *irc.Prefix) *irc.Message {
 	cmd := irc.RPL_NOWAWAY
 	desc := "You have been marked as being away"
 	if !away {
@@ -307,6 +307,7 @@ func generateAwayReply(away bool) *irc.Message {
 		desc = "You are no longer marked as being away"
 	}
 	return &irc.Message{
+		Prefix:  prefix,
 		Command: cmd,
 		Params:  []string{"*", desc},
 	}


### PR DESCRIPTION
Prefix seems to be required on numeric server responses. Without it, clients like hexchat can't parse it at all and ignore it. This prevents /back from working, hexchat won't let you unaway unless it parses the original /away