### PR TITLE
Include prefix in CAP messages again

### DIFF
--- a/downstream.go
+++ b/downstream.go
@@ -799,6 +799,7 @@ func (dc *downstreamConn) handleCap(ctx context.Context, msg *irc.Message) error
 
 		// TODO: multi-line replies
 		dc.SendMessage(ctx, &irc.Message{
+			Prefix:  dc.srv.prefix(),
 			Command: "CAP",
 			Params:  []string{dc.nick, "LS", strings.Join(caps, " ")},
 		})
@@ -819,6 +820,7 @@ func (dc *downstreamConn) handleCap(ctx context.Context, msg *irc.Message) error
 
 		// TODO: multi-line replies
 		dc.SendMessage(ctx, &irc.Message{
+			Prefix:  dc.srv.prefix(),
 			Command: "CAP",
 			Params:  []string{dc.nick, "LIST", strings.Join(caps, " ")},
 		})
@@ -876,6 +878,7 @@ func (dc *downstreamConn) handleCap(ctx context.Context, msg *irc.Message) error
 			reply = "ACK"
 		}
 		dc.SendMessage(ctx, &irc.Message{
+			Prefix:  dc.srv.prefix(),
 			Command: "CAP",
 			Params:  []string{dc.nick, reply, args[0]},
 		})
@@ -1037,6 +1040,7 @@ func (dc *downstreamConn) setSupportedCap(ctx context.Context, name, value strin
 	}
 
 	dc.SendMessage(ctx, &irc.Message{
+		Prefix:  dc.srv.prefix(),
 		Command: "CAP",
 		Params:  []string{dc.nick, "NEW", cap},
 	})
@@ -1051,6 +1055,7 @@ func (dc *downstreamConn) unsetSupportedCap(ctx context.Context, name string) {
 	}
 
 	dc.SendMessage(ctx, &irc.Message{
+		Prefix:  dc.srv.prefix(),
 		Command: "CAP",
 		Params:  []string{dc.nick, "DEL", name},
 	})


### PR DESCRIPTION
Buggy clients like hexchat can't parse CAP otherwise, making it unable to connect at all. I'm unsure if any other clients out there have this bug. My mobile client is unaffected, and even the irc bots I wrote correctly assume prefix is optional.

The bug is on the hexchat side, but given the severity (being unable to make it past the registration phase), I hope this will be merged anyway. The spec says clients may leave source out, but it also says they may include it anyway ...

This commit is just a partial revert of c36140fb2ab3955374fe1604ee40bf29dd79dfc4
I checked the other removals, and most are in modern IRC extensions like BATCH, BOUNCER, and CHATHISTORY, any client that supports these should already be following the spec and handle lack of prefix fine. Prefix also got removed from AUTHENTICATE, but that is one of a handful that hexchat supports without a prefix, and I tested that one works fine.