### PR TITLE
Update znc-import tool to tell the user to use sojudb not sojuctl to change passwords for imported users.

### DIFF
--- a/contrib/znc-import/main.go
+++ b/contrib/znc-import/main.go
@@ -232,7 +232,7 @@ func main() {
 	}
 
 	if usersCreated > 0 {
-		log.Printf("warning: user passwords haven't been imported, please set them with `sojuctl change-password <username>`")
+		log.Printf("warning: user passwords haven't been imported, please set them with `sojudb change-password <username>`")
 	}
 
 	log.Printf("imported %v users, %v networks and %v channels", usersImported, networksImported, channelsImported)


### PR DESCRIPTION


change-password is a subcommand of sojudb. znc-import does not import user passwords and needs to tell the user to use that tool.